### PR TITLE
Initial commits

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@next/font": "13.4.1",
     "eslint": "8.40.0",
     "eslint-config-next": "13.4.1",
     "next": "13.4.1",

--- a/src/modules/Sections/About.js
+++ b/src/modules/Sections/About.js
@@ -9,7 +9,7 @@ const About = () => (
     <div className="About-PrimaryContainer">
       <div className="AboutImg">
         <Image
-          src="./img/Steve-hero-1.png"
+          src="/img/Steve-hero-1.png"
           width={400}
           height={400}
           alt="Steve"

--- a/src/modules/Sections/Hero.js
+++ b/src/modules/Sections/Hero.js
@@ -54,7 +54,7 @@ const Hero = () => (
 
       <div className="HeroImg">
         <Image
-          src="./img/Steve-hero3.png"
+          src="/img/Steve-hero3.png"
           width={624}
           height={469}
           alt="Steve"

--- a/src/modules/Sections/Roadmap.js
+++ b/src/modules/Sections/Roadmap.js
@@ -15,7 +15,7 @@ const Roadmap = () => (
         <div className="RoadMapHero">
           <div className="RoadMapHeroImg">
             <Image
-              src="./img/focused-steve.png"
+              src="/img/focused-steve.png"
               width={500}
               height={508}
               alt="Steve"
@@ -31,7 +31,7 @@ const Roadmap = () => (
         <div className="Phases">
           <div className="Phase1 Phase">
             <Image
-              src="./img/phase1.png"
+              src="/img/phase1.png"
               width={680}
               height={440}
               alt="Steve"
@@ -47,7 +47,7 @@ const Roadmap = () => (
 
           <div className="Phase2 Phase">
             <Image
-              src="./img/phase2.png"
+              src="/img/phase2.png"
               width={680}
               height={440}
               alt="Steve"
@@ -63,7 +63,7 @@ const Roadmap = () => (
 
           <div className="Phase3 Phase">
             <Image
-              src="./img/phase3.png"
+              src="/img/phase3.png"
               width={680}
               height={440}
               alt="Steve"

--- a/src/modules/Sections/Tokenomics.js
+++ b/src/modules/Sections/Tokenomics.js
@@ -42,7 +42,7 @@ const Tokenomics = () => (
           </div>
           <div className="TokenSupplyImg">
             <Image
-              src="./img/angry-steve.png"
+              src="/img/angry-steve.png"
               width={550}
               height={589}
               alt="Steve"

--- a/src/modules/nav/SiteHeader.js
+++ b/src/modules/nav/SiteHeader.js
@@ -16,7 +16,7 @@ const SiteHeader = () => {
     <div className="InnerContainer">
     <header>
       <div className="nav-assets">
-        <Image src="./img/logo.png" width={210} height={129} alt="Steve" />
+        <Image src="/img/logo.png" width={210} height={129} alt="Steve" />
         <div className="HamburgerContainer" onClick={toggleMM}>
           <Hamburger/>
         </div>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,6 @@
 import Head from 'next/head';
 import Image from 'next/image';
-import { Inter } from '@next/font/google';
+import { Inter } from "next/font/google";
 import { PrimaryContainer } from '../Templates/Primary-Container';
 import { Meta } from '../modules/head/Meta';
 import { GetStaticProps } from 'next';


### PR DESCRIPTION
Updated next/font to remove warning:
- warn Your project has `@next/font` installed as a dependency, please use the built-in `next/font` instead. The `@next/font` package will be removed in Next.js 14. You can migrate by running `npx @next/codemod@latest built-in-next-font .`. Read more: https://nextjs.org/docs/messages/built-in-next-font

Changed img paths (./img to /img) to fix errors:
Error: Failed to parse src "./img/logo.png" on `next/image`, if using relative image it must start with a leading slash "/" or be an absolute URL (http:// or https://)